### PR TITLE
grass: build plugins with default python version

### DIFF
--- a/pkgs/grass/plugins.nix
+++ b/pkgs/grass/plugins.nix
@@ -14,12 +14,11 @@
 , mpfr
 , pkg-config
 , postgresql
-, python311Packages
+, python3Packages
 }:
 
 let
   srcRevision = import ./plugins-rev.nix;
-  pyPackages = python311Packages;
 
 in
 stdenv.mkDerivation {
@@ -45,7 +44,7 @@ stdenv.mkDerivation {
     find . -name '*.pyc' -type f -delete
   '';
 
-  nativeBuildInputs = with pyPackages; [
+  nativeBuildInputs = with python3Packages; [
     pkg-config
 
     grass
@@ -60,7 +59,7 @@ stdenv.mkDerivation {
   ];
 
   # extra plugin dependencies (both Python and non-python)
-  propagatedBuildInputs = with pyPackages; [ ]
+  propagatedBuildInputs = with python3Packages; [ ]
     # python
     ++ lib.optionals (name == "m-cdo-download") [ requests ]
     ++ lib.optionals (name == "m-tnm-download") [ requests ]


### PR DESCRIPTION
Merge after https://github.com/NixOS/nixpkgs/pull/359762 is in unstable.